### PR TITLE
feat(ui): fix table width to prevent content  jump

### DIFF
--- a/packages/ui/src/components/Table/BaseTable.css
+++ b/packages/ui/src/components/Table/BaseTable.css
@@ -5,6 +5,7 @@ button {
 table {
   border-collapse: collapse;
   border-spacing: 0;
+  table-layout: fixed;
   width: 100%;
 }
 
@@ -38,6 +39,8 @@ td {
   padding: 8px;
   text-align: left;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 th>div>span {

--- a/packages/ui/src/components/Table/TableBody.tsx
+++ b/packages/ui/src/components/Table/TableBody.tsx
@@ -11,7 +11,7 @@ function TableBody<T>(properties: TableBodyProperties<T>) {
           <tr key={row.id}>
             {row.getVisibleCells().map((cell: Cell<T, unknown>) => {
               return (
-                <td key={cell.id}>
+                <td key={cell.id} style={{ width: cell.column.getSize() }}>
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </td>
               );

--- a/packages/ui/src/components/Table/TableHeader.tsx
+++ b/packages/ui/src/components/Table/TableHeader.tsx
@@ -38,7 +38,11 @@ function TableHeader<T>({ table }: TableHeaderProperties<T>) {
             };
 
             return (
-              <th key={header.id} colSpan={header.colSpan}>
+              <th
+                key={header.id}
+                colSpan={header.colSpan}
+                style={{ width: header.getSize() }}
+              >
                 {header.isPlaceholder ? null : (
                   <div
                     {...{


### PR DESCRIPTION
- The size for column can be provided from app in following syntax:

```jsx
      {
        accessorKey: "id",
        header: () => <span>ID</span>,
        size: 20
      },
```

- The column without fixed size **expands** to fill remaining width