### PR TITLE
refactor(ui): reject and accept implementation of confirmation modal

### DIFF
--- a/packages/ui/src/ConfirmationModal/index.tsx
+++ b/packages/ui/src/ConfirmationModal/index.tsx
@@ -29,18 +29,12 @@ export const ConfirmationModal = ({
           label="No"
           variant="outlined"
           severity="secondary"
-          onClick={() => {
-            reject?.();
-            onHide?.();
-          }}
+          onClick={reject || onHide}
           {...cancelButtonOptions}
         />
         <Button
           label="Yes"
-          onClick={() => {
-            accept?.();
-            onHide?.();
-          }}
+          onClick={accept || onHide}
           {...acceptButtonOptions}
         />
       </div>

--- a/packages/ui/src/DataTable/components/Actions/index.tsx
+++ b/packages/ui/src/DataTable/components/Actions/index.tsx
@@ -20,11 +20,11 @@ export interface ActionsMenuProperties {
   viewLabel?: string;
   requireConfirmationOnDelete?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onDelete?: (arguments_: any) => void;
+  onDelete?: (arguments_: any) => void | Promise<void>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onEdit?: (arguments_: any) => void;
+  onEdit?: (arguments_: any) => void | Promise<void>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onView?: (arguments_: any) => void;
+  onView?: (arguments_: any) => void | Promise<void>;
 }
 
 export const ActionsMenu = ({
@@ -95,8 +95,9 @@ export const ActionsMenu = ({
           message={deleteConfirmationMessage}
           header={deleteConfirmationHeader}
           onHide={() => setShowDeleteConfirmation(false)}
-          accept={() => {
-            onDelete(data);
+          accept={async () => {
+            await onDelete(data);
+
             setShowDeleteConfirmation(false);
           }}
         />

--- a/packages/ui/src/FileCard/ConfirmationFileActions.tsx
+++ b/packages/ui/src/FileCard/ConfirmationFileActions.tsx
@@ -7,10 +7,8 @@ import type { IFile } from "..";
 type ConfirmationFileActionsType = {
   visibleArchiveConfirmation: boolean;
   visibleDeleteConfirmation: boolean;
-
-  onArchive?: (arguments_: IFile) => void;
-
-  onDelete?: (arguments_: IFile) => void;
+  onArchive?: (arguments_: IFile) => void | Promise<void>;
+  onDelete?: (arguments_: IFile) => void | Promise<void>;
   file: IFile;
   setVisibleArchiveConfirmation: (isVisible: boolean) => void;
   setVisibleDeleteConfirmation: (isVisible: boolean) => void;
@@ -41,8 +39,9 @@ const ConfirmationFileActions: FC<ConfirmationFileActionsType> = ({
     <>
       <ConfirmationModal
         visible={visibleArchiveConfirmation}
-        accept={() => {
-          onArchive?.(file);
+        accept={async () => {
+          await onArchive?.(file);
+
           setVisibleArchiveConfirmation(false);
         }}
         reject={() => {
@@ -60,8 +59,9 @@ const ConfirmationFileActions: FC<ConfirmationFileActionsType> = ({
       />
       <ConfirmationModal
         visible={visibleDeleteConfirmation}
-        accept={() => {
-          onDelete?.(file);
+        accept={async () => {
+          await onDelete?.(file);
+
           setVisibleDeleteConfirmation(false);
         }}
         reject={() => setVisibleDeleteConfirmation(false)}

--- a/packages/ui/src/Table/TableDataActions.tsx
+++ b/packages/ui/src/Table/TableDataActions.tsx
@@ -10,7 +10,7 @@ export interface DataActionsMenuItem
   extends Omit<MenuItem, "command" | "disabled"> {
   requireConfirmationModal?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onClick?: (arguments_: any) => void;
+  onClick?: (arguments_: any) => void | Promise<void>;
   confirmationOptions?: IModalProperties;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   disabled?: boolean | ((data: any) => boolean);
@@ -71,8 +71,9 @@ export const DataActionsMenu = ({
               setConfirmation({
                 ...action.confirmationOptions,
                 onHide: () => setConfirmation(null),
-                accept: () => {
-                  action.onClick && action.onClick(data);
+                accept: async () => {
+                  await action.onClick?.(data);
+
                   setConfirmation(null);
                 },
               });


### PR DESCRIPTION
refactor(ui): reject and accept implementation of confirmation modal

BREAKING CHANGE: The `accept` and `reject` function is now responsible for closing the modal. This change allows developers to handle asynchronous operations and error handling more flexibly."