### PR TITLE
feat(layout): expand user-menu upward with label fixed at the bottom

### DIFF
--- a/packages/layout/src/assets/css/components/layout/common/nav-group.css
+++ b/packages/layout/src/assets/css/components/layout/common/nav-group.css
@@ -1,30 +1,24 @@
 .dz-nav-group {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
   padding: 0;
-}
-
-.dz-nav-group > .dz-nav-header {
-  color: var(--dz-layout-nav-item-color, #ffffff);
-  padding: var(--dz-layout-nav-item-padding-v, 0.625rem)
-    var(--dz-layout-nav-item-padding-h, 1rem);
 }
 
 .dz-nav-group > .dz-group-submenu {
   display: flex;
   align-items: start;
   flex-direction: column;
-  gap: 0.25rem;
   padding: 0;
   margin: 0;
   overflow: hidden;
   max-height: 0;
-  transition: all 0.5s ease;
+  transition: padding 0.4s ease-out, box-shadow 0.5s ease-out,
+    max-height 0.5s ease;
 }
 
-.dz-nav-group[aria-expanded="true"] > .dz-group-submenu {
+.dz-nav-group[aria-expanded="true"] > ul.dz-group-submenu {
   max-height: 500px;
+  padding: 0.5rem 0;
 }
 
 .dz-nav-group .dz-group-submenu > li {
@@ -40,14 +34,16 @@
 }
 
 .dz-nav-group .dz-nav-group-toggle {
-  transition: transform 0.3s ease-in;
+  transition: transform 0.5s ease;
 }
 
-.dz-nav-group > .dz-nav-item .dz-nav-group-toggle {
+.dz-nav-group.collapsible > .dz-nav-item .dz-nav-group-toggle {
   transform: rotate(90deg);
 }
 
-.dz-nav-group[aria-expanded="true"] > .dz-nav-item .dz-nav-group-toggle {
+.dz-nav-group.collapsible[aria-expanded="true"]
+  > .dz-nav-item
+  .dz-nav-group-toggle {
   transform: rotate(-90deg);
 }
 
@@ -67,12 +63,31 @@
 
 .dz-nav-group.collapsible-reverse[aria-expanded="true"] ul.dz-group-submenu {
   box-shadow: 0 -2px 12px 0 rgba(0, 0, 0, 0.1);
-  padding: 0.5rem 0;
   animation: levitate 1s ease forwards;
 }
 
 .dz-nav-group.collapsible-reverse .dz-group-submenu .dz-nav-item {
   padding-left: var(--_nav-item-padding-h);
+}
+
+.dz-nav-group.collapsible-reverse > .dz-nav-item .dz-nav-group-toggle {
+  transform: rotate(-90deg);
+}
+
+.dz-nav-group.collapsible-reverse[aria-expanded="true"]
+  > .dz-nav-item
+  .dz-nav-group-toggle {
+  transform: rotate(90deg);
+}
+
+/* Expanded */
+.dz-nav-group.expanded > .dz-nav-item .dz-nav-group-toggle {
+  display: none;
+}
+
+.dz-nav-group.expanded > .dz-nav-item.dz-group-header {
+  background: unset;
+  cursor: default;
 }
 
 @keyframes levitate {

--- a/packages/layout/src/assets/css/components/layout/common/nav-group.css
+++ b/packages/layout/src/assets/css/components/layout/common/nav-group.css
@@ -5,6 +5,12 @@
   padding: 0;
 }
 
+.dz-nav-group > .dz-nav-header {
+  color: var(--dz-layout-nav-item-color, #ffffff);
+  padding: var(--dz-layout-nav-item-padding-v, 0.625rem)
+    var(--dz-layout-nav-item-padding-h, 1rem);
+}
+
 .dz-nav-group > .dz-group-submenu {
   display: flex;
   align-items: start;

--- a/packages/layout/src/assets/css/components/layout/common/nav-group.css
+++ b/packages/layout/src/assets/css/components/layout/common/nav-group.css
@@ -20,8 +20,7 @@
   margin: 0;
   overflow: hidden;
   max-height: 0;
-  animation: expand 120ms ease;
-  transition: max-height 0.4s ease-in-out;
+  transition: all 0.5s ease;
 }
 
 .dz-nav-group[aria-expanded="true"] > .dz-group-submenu {
@@ -52,21 +51,38 @@
   transform: rotate(-90deg);
 }
 
-@keyframes expand {
+/* Collapsible-reverse */
+.dz-nav-group.collapsible-reverse {
+  position: relative;
+}
+
+.dz-nav-group.collapsible-reverse ul.dz-group-submenu {
+  position: absolute;
+  background: var(--_layout-sidebar-bg);
+  bottom: 100%;
+  margin: 1px 0;
+  width: 100%;
+  z-index: 2;
+}
+
+.dz-nav-group.collapsible-reverse[aria-expanded="true"] ul.dz-group-submenu {
+  box-shadow: 0 -2px 12px 0 rgba(0, 0, 0, 0.1);
+  padding: 0.5rem 0;
+  animation: levitate 1s ease forwards;
+}
+
+.dz-nav-group.collapsible-reverse .dz-group-submenu .dz-nav-item {
+  padding-left: var(--_nav-item-padding-h);
+}
+
+@keyframes levitate {
   0% {
-    opacity: 0;
-    transform: translateY(-12px);
+    transform: translateY(0);
   }
-  25% {
-    opacity: 0.5;
-    transform: translateY(0px);
-  }
-  75% {
-    opacity: 0.75;
-    transform: translateY(0px);
+  50% {
+    transform: translateY(-3px);
   }
   100% {
-    opacity: 1;
-    transform: translateY(0px);
+    transform: translateY(0);
   }
 }

--- a/packages/layout/src/assets/css/components/layout/header-menu.css
+++ b/packages/layout/src/assets/css/components/layout/header-menu.css
@@ -9,6 +9,7 @@
   flex-wrap: wrap;
   color: var(--_layout-header-color);
   flex-direction: column;
+  gap: 0.25rem;
 }
 
 .dz-layout .dz-header-menu > ul.dz-user-menu {

--- a/packages/layout/src/assets/css/components/layout/sidebar.css
+++ b/packages/layout/src/assets/css/components/layout/sidebar.css
@@ -31,8 +31,7 @@
   color: var(--_layout-sidebar-color);
 }
 
-.dz-layout[aria-expanded="false"] > .dz-sidebar > .dz-navigation-menu,
-.dz-layout[aria-expanded="false"] > .dz-sidebar > .dz-sidebar-footer {
+.dz-layout[aria-expanded="false"] > .dz-sidebar > :not(.dz-sidebar-header) {
   display: none;
 }
 

--- a/packages/layout/src/assets/css/layouts/sidebar-header-layout.css
+++ b/packages/layout/src/assets/css/layouts/sidebar-header-layout.css
@@ -14,11 +14,6 @@
   grid-area: header;
 }
 
-.dz-sidebar-header-layout > .dz-sidebar > .dz-user-menu,
-.dz-sidebar-header-layout > .dz-sidebar > .dz-user-menu-item {
-  display: none;
-}
-
 .dz-sidebar-header-layout > main {
   grid-area: main;
   max-width: 100%;
@@ -54,23 +49,7 @@
     justify-content: flex-end;
   }
 
-  .dz-sidebar-header-layout > .dz-sidebar > .dz-navigation-menu > .dz-user-menu,
-  .dz-sidebar-header-layout
-    > .dz-sidebar
-    > .dz-navigation-menu
-    > .dz-user-menu-item {
-    display: none;
-  }
-
   /* user-menu-location --> header */
-  .dz-sidebar-header-layout[data-user-menu-location="header"]
-    > .dz-sidebar
-    > .dz-navigation-menu
-    > .dz-user-menu,
-  .dz-sidebar-header-layout[data-user-menu-location="header"]
-    > .dz-sidebar
-    > .dz-navigation-menu
-    > .dz-auth-menu,
   .dz-sidebar-header-layout[data-user-menu-location="header"]
     > .dz-sidebar
     > .dz-user-menu,
@@ -92,15 +71,7 @@
   .dz-sidebar-header-layout[data-user-menu-location="sidebar"]
     > header
     .dz-header-menu
-    > .dz-user-menu,
-  .dz-sidebar-header-layout[data-user-menu-location="sidebar"]
-    > header
-    .dz-header-menu
-    > .dz-auth-menu,
-  .dz-sidebar-header-layout[data-user-menu-location="sidebar"]
-    > header
-    .dz-header-menu
-    > .dz-user-menu-item {
+    > .dz-user-menu {
     display: none;
   }
 }

--- a/packages/layout/src/assets/css/layouts/sidebar-only-layout.css
+++ b/packages/layout/src/assets/css/layouts/sidebar-only-layout.css
@@ -10,10 +10,6 @@
   grid-area: header;
 }
 
-.dz-sidebar-only-layout > .dz-sidebar > .dz-user-menu {
-  display: none;
-}
-
 .dz-sidebar-only-layout > main {
   grid-area: main;
   max-width: 100%;
@@ -34,14 +30,5 @@
 
   .dz-sidebar-only-layout > main {
     overflow-y: auto;
-  }
-
-  .dz-sidebar-only-layout > .dz-sidebar > .dz-user-menu {
-    display: flex;
-    padding: 0.5rem 0;
-  }
-
-  .dz-sidebar-only-layout > .dz-sidebar > .dz-navigation-menu > .dz-user-menu {
-    display: none;
   }
 }

--- a/packages/layout/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/packages/layout/src/components/Layout/Sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import { SidebarHeader } from "./Header";
 import { NavigationMenu } from "../common";
 import { UserMenu } from "../common/UserMenu";
 
-import type { NavMenuItemType, NavMenuType, UserMenuModeType } from "../types";
+import type { NavMenuItemType, NavMenuType } from "../types";
 
 type SidebarProperties = {
   children?: React.ReactNode;

--- a/packages/layout/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/packages/layout/src/components/Layout/Sidebar/Sidebar.tsx
@@ -3,7 +3,11 @@ import { SidebarHeader } from "./Header";
 import { NavigationMenu } from "../common";
 import { UserMenu } from "../common/UserMenu";
 
-import type { NavMenuItemType, NavMenuType } from "../types";
+import type {
+  NavGroupDisplayMode,
+  NavMenuItemType,
+  NavMenuType,
+} from "../types";
 
 type SidebarProperties = {
   children?: React.ReactNode;
@@ -14,7 +18,7 @@ type SidebarProperties = {
   noHeader?: boolean;
   noLocaleSwitcher?: boolean;
   userMenu?: NavMenuItemType;
-  userMenuMode?: "collapsible" | "collapsible-reverse";
+  userMenuMode?: NavGroupDisplayMode;
   trigger?: React.ReactNode;
 };
 

--- a/packages/layout/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/packages/layout/src/components/Layout/Sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import { SidebarHeader } from "./Header";
 import { NavigationMenu } from "../common";
 import { UserMenu } from "../common/UserMenu";
 
-import type { NavMenuItemType, NavMenuType } from "../types";
+import type { NavMenuItemType, NavMenuType, UserMenuModeType } from "../types";
 
 type SidebarProperties = {
   children?: React.ReactNode;
@@ -14,6 +14,7 @@ type SidebarProperties = {
   noHeader?: boolean;
   noLocaleSwitcher?: boolean;
   userMenu?: NavMenuItemType;
+  userMenuMode?: "popup" | "collapsible" | "collapsible-reverse";
   trigger?: React.ReactNode;
 };
 
@@ -26,6 +27,7 @@ export const Sidebar = ({
   noHeader = false,
   noLocaleSwitcher = false,
   userMenu,
+  userMenuMode,
   trigger,
 }: SidebarProperties) => {
   const renderContent = () => {
@@ -40,7 +42,7 @@ export const Sidebar = ({
           <UserMenu
             menu={userMenu}
             trigger={trigger}
-            userMenuMode="expandable"
+            userMenuMode={userMenuMode}
           />
         )}
         {!noFooter && <SidebarFooter noLocaleSwitcher={noLocaleSwitcher} />}

--- a/packages/layout/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/packages/layout/src/components/Layout/Sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ type SidebarProperties = {
   noHeader?: boolean;
   noLocaleSwitcher?: boolean;
   userMenu?: NavMenuItemType;
-  userMenuMode?: "popup" | "collapsible" | "collapsible-reverse";
+  userMenuMode?: "collapsible" | "collapsible-reverse";
   trigger?: React.ReactNode;
 };
 

--- a/packages/layout/src/components/Layout/common/NavigationMenu/NavGroup.tsx
+++ b/packages/layout/src/components/Layout/common/NavigationMenu/NavGroup.tsx
@@ -22,7 +22,7 @@ export const NavGroup = ({
   className = "",
 }: NavGroupProperties) => {
   const [showSubmenu, setShowSubmenu] = useState(
-    initialVisible || displayMode === "expanded"
+    initialVisible || displayMode === "expanded",
   );
 
   const renderSubmenu = useCallback(() => {

--- a/packages/layout/src/components/Layout/common/NavigationMenu/NavGroup.tsx
+++ b/packages/layout/src/components/Layout/common/NavigationMenu/NavGroup.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { Navigation } from "./Navigation";
 import { NavItem } from "./NavItem";
@@ -23,7 +23,7 @@ export const NavGroup = ({
 }: NavGroupProperties) => {
   const [showSubmenu, setShowSubmenu] = useState(initialVisible);
 
-  const renderSubmenu = () => {
+  const renderSubmenu = useCallback(() => {
     return (
       <ul className="dz-group-submenu">
         {navGroup.submenu &&
@@ -42,7 +42,7 @@ export const NavGroup = ({
           })}
       </ul>
     );
-  };
+  }, [displayIcon, horizontal, navGroup]);
 
   return (
     <div

--- a/packages/layout/src/components/Layout/common/NavigationMenu/NavGroup.tsx
+++ b/packages/layout/src/components/Layout/common/NavigationMenu/NavGroup.tsx
@@ -1,4 +1,3 @@
-import { useMediaQuery } from "@dzangolab/react-ui";
 import { useState } from "react";
 
 import { Navigation } from "./Navigation";
@@ -6,6 +5,8 @@ import { NavItem } from "./NavItem";
 import { NavGroupType } from "../../types";
 
 export type NavGroupProperties = {
+  initialVisible?: boolean;
+  collapsible?: boolean;
   displayIcon?: boolean;
   horizontal?: boolean;
   navGroup: NavGroupType;
@@ -13,13 +14,14 @@ export type NavGroupProperties = {
 };
 
 export const NavGroup = ({
+  collapsible = true,
+  initialVisible = false,
   displayIcon = true,
   horizontal,
   navGroup,
   className = "",
 }: NavGroupProperties) => {
-  const [showSubmenu, setShowSubmenu] = useState(false);
-  const isSmallScreen = useMediaQuery("(max-width:576px)");
+  const [showSubmenu, setShowSubmenu] = useState(initialVisible);
 
   const renderSubmenu = () => {
     return (
@@ -42,24 +44,20 @@ export const NavGroup = ({
     );
   };
 
-  const navGroupProperties =
-    isSmallScreen || !horizontal
-      ? {
-          className: `dz-nav-group ${className}`.trim(),
-          "aria-expanded": showSubmenu,
-        }
-      : { className: `dz-nav-group ${className}`.trim() };
-
   return (
-    <div {...navGroupProperties}>
+    <div
+      className={`dz-nav-group ${className}`.trim()}
+      aria-expanded={showSubmenu}
+    >
       <NavItem
         navItem={{
           label: navGroup.label,
           icon: navGroup.icon,
-          onClick: () => setShowSubmenu(!showSubmenu),
+          onClick: () => collapsible && setShowSubmenu(!showSubmenu),
         }}
         displayIcon={displayIcon}
         isGroupHeader
+        collapsible={collapsible}
       ></NavItem>
       {renderSubmenu()}
     </div>

--- a/packages/layout/src/components/Layout/common/NavigationMenu/NavGroup.tsx
+++ b/packages/layout/src/components/Layout/common/NavigationMenu/NavGroup.tsx
@@ -2,26 +2,28 @@ import { useCallback, useState } from "react";
 
 import { Navigation } from "./Navigation";
 import { NavItem } from "./NavItem";
-import { NavGroupType } from "../../types";
+import { NavGroupDisplayMode, NavGroupType } from "../../types";
 
 export type NavGroupProperties = {
   initialVisible?: boolean;
-  collapsible?: boolean;
   displayIcon?: boolean;
   horizontal?: boolean;
   navGroup: NavGroupType;
   className?: string;
+  displayMode?: NavGroupDisplayMode;
 };
 
 export const NavGroup = ({
-  collapsible = true,
+  displayMode = "collapsible",
   initialVisible = false,
   displayIcon = true,
   horizontal,
   navGroup,
   className = "",
 }: NavGroupProperties) => {
-  const [showSubmenu, setShowSubmenu] = useState(initialVisible);
+  const [showSubmenu, setShowSubmenu] = useState(
+    initialVisible || displayMode === "expanded"
+  );
 
   const renderSubmenu = useCallback(() => {
     return (
@@ -46,18 +48,18 @@ export const NavGroup = ({
 
   return (
     <div
-      className={`dz-nav-group ${className}`.trim()}
+      className={`dz-nav-group ${displayMode} ${className}`.trim()}
       aria-expanded={showSubmenu}
     >
       <NavItem
         navItem={{
           label: navGroup.label,
           icon: navGroup.icon,
-          onClick: () => collapsible && setShowSubmenu(!showSubmenu),
+          onClick: () =>
+            displayMode !== "expanded" && setShowSubmenu(!showSubmenu),
         }}
         displayIcon={displayIcon}
         isGroupHeader
-        collapsible={collapsible}
       ></NavItem>
       {renderSubmenu()}
     </div>

--- a/packages/layout/src/components/Layout/common/NavigationMenu/NavItem.tsx
+++ b/packages/layout/src/components/Layout/common/NavigationMenu/NavItem.tsx
@@ -6,16 +6,20 @@ export type NavItemProperties = {
   displayIcon?: boolean;
   navItem: NavItemType;
   isGroupHeader?: boolean;
+  collapsible?: boolean;
 };
 
 export const NavItem = ({
   navItem,
   displayIcon = true,
   isGroupHeader,
+  collapsible = true,
 }: NavItemProperties) => {
   const hasRouterContext = useInRouterContext();
 
-  const _className = `dz-nav-item ${navItem.className || ""}`.trim();
+  const _className = `${
+    isGroupHeader && !collapsible ? "dz-nav-header" : "dz-nav-item"
+  } ${navItem.className || ""}`.trim();
 
   if ("display" in navItem && !navItem.display) {
     return null;
@@ -26,9 +30,6 @@ export const NavItem = ({
       <div className={_className} aria-disabled={navItem.disabled}>
         {displayIcon && navItem.icon && <i className={navItem.icon}></i>}
         <span>{navItem.label}</span>
-        {isGroupHeader && (
-          <i className="pi pi-angle-right dz-nav-group-toggle" />
-        )}
       </div>
     );
   }
@@ -38,7 +39,7 @@ export const NavItem = ({
       <div className={_className} onClick={navItem.onClick}>
         {displayIcon && navItem.icon && <i className={navItem.icon}></i>}
         <span>{navItem.label}</span>
-        {isGroupHeader && (
+        {isGroupHeader && collapsible && (
           <i className="pi pi-angle-right dz-nav-group-toggle" />
         )}
       </div>

--- a/packages/layout/src/components/Layout/common/NavigationMenu/NavItem.tsx
+++ b/packages/layout/src/components/Layout/common/NavigationMenu/NavItem.tsx
@@ -6,20 +6,18 @@ export type NavItemProperties = {
   displayIcon?: boolean;
   navItem: NavItemType;
   isGroupHeader?: boolean;
-  collapsible?: boolean;
 };
 
 export const NavItem = ({
   navItem,
   displayIcon = true,
   isGroupHeader,
-  collapsible = true,
 }: NavItemProperties) => {
   const hasRouterContext = useInRouterContext();
 
-  const _className = `${
-    isGroupHeader && !collapsible ? "dz-nav-header" : "dz-nav-item"
-  } ${navItem.className || ""}`.trim();
+  const _className = `dz-nav-item ${isGroupHeader ? "dz-group-header" : ""} ${
+    navItem.className || ""
+  }`.trim();
 
   if ("display" in navItem && !navItem.display) {
     return null;
@@ -39,7 +37,7 @@ export const NavItem = ({
       <div className={_className} onClick={navItem.onClick}>
         {displayIcon && navItem.icon && <i className={navItem.icon}></i>}
         <span>{navItem.label}</span>
-        {isGroupHeader && collapsible && (
+        {isGroupHeader && (
           <i className="pi pi-angle-right dz-nav-group-toggle" />
         )}
       </div>

--- a/packages/layout/src/components/Layout/common/UserMenu/UserMenu.tsx
+++ b/packages/layout/src/components/Layout/common/UserMenu/UserMenu.tsx
@@ -12,8 +12,9 @@ interface IProperties {
 }
 
 export const UserMenu = ({ menu, userMenuMode, trigger }: IProperties) => {
-  const navigate = useNavigate();
   const { label: userMenuLabel, menu: userMenu = [] } = menu;
+
+  const navigate = useNavigate();
 
   const refinedMenu = useMemo(
     () =>
@@ -56,38 +57,62 @@ export const UserMenu = ({ menu, userMenuMode, trigger }: IProperties) => {
       );
     }
 
-    if (userMenuMode === "horizontal") {
-      return (
-        <ul className="dz-user-menu" aria-orientation={userMenuMode}>
-          {refinedMenu.map(({ onClick, ..._menuItem }) => {
-            return (
-              <li key={_menuItem.label} onClick={onClick}>
-                {template(_menuItem)}
-              </li>
-            );
-          })}
-        </ul>
-      );
+    switch (userMenuMode) {
+      case "horizontal":
+        return (
+          <ul className="dz-user-menu" aria-orientation={userMenuMode}>
+            {refinedMenu.map(({ onClick, ..._menuItem }) => {
+              return (
+                <li key={_menuItem.label} onClick={onClick}>
+                  {template(_menuItem)}
+                </li>
+              );
+            })}
+          </ul>
+        );
+      case "popup":
+        return (
+          <DropdownMenu
+            className="dz-user-menu"
+            renderOption={template}
+            menu={refinedMenu || []}
+            label={userMenuLabel}
+            trigger={trigger}
+          />
+        );
+      case "collapsible":
+        return (
+          <NavGroup
+            className="dz-user-menu"
+            navGroup={{
+              label: userMenuLabel,
+              submenu: refinedMenu,
+            }}
+          />
+        );
+      case "collapsible-reverse":
+        return (
+          <NavGroup
+            className={`dz-user-menu ${userMenuMode}`}
+            navGroup={{
+              label: userMenuLabel,
+              submenu: refinedMenu,
+            }}
+          />
+        );
+      default:
+        return (
+          <NavGroup
+            initialVisible={true}
+            collapsible={false}
+            className="dz-user-menu"
+            navGroup={{
+              label: userMenuLabel,
+              submenu: refinedMenu,
+            }}
+          />
+        );
     }
-
-    return userMenuMode === "expandable" ? (
-      <NavGroup
-        className="dz-user-menu"
-        displayIcon
-        navGroup={{
-          label: userMenuLabel,
-          submenu: refinedMenu,
-        }}
-      />
-    ) : (
-      <DropdownMenu
-        className="dz-user-menu"
-        renderOption={template}
-        menu={refinedMenu || []}
-        label={userMenuLabel}
-        trigger={trigger}
-      />
-    );
   };
 
   return userMenu.length ? renderContent() : null;

--- a/packages/layout/src/components/Layout/common/UserMenu/UserMenu.tsx
+++ b/packages/layout/src/components/Layout/common/UserMenu/UserMenu.tsx
@@ -50,10 +50,12 @@ export const UserMenu = ({ menu, userMenuMode, trigger }: IProperties) => {
       const _menuItem = refinedMenu[0];
 
       return (
-        <span className="dz-user-menu-item" onClick={_menuItem.onClick}>
-          {_menuItem.icon && <i className={_menuItem.icon}></i>}
-          {_menuItem.label}
-        </span>
+        <ul className="dz-user-menu">
+          <span className="dz-user-menu-item" onClick={_menuItem.onClick}>
+            {_menuItem.icon && <i className={_menuItem.icon}></i>}
+            {_menuItem.label}
+          </span>
+        </ul>
       );
     }
 

--- a/packages/layout/src/components/Layout/common/UserMenu/UserMenu.tsx
+++ b/packages/layout/src/components/Layout/common/UserMenu/UserMenu.tsx
@@ -32,7 +32,7 @@ export const UserMenu = ({ menu, userMenuMode, trigger }: IProperties) => {
           },
         };
       }),
-    [userMenu],
+    [userMenu]
   );
 
   const renderContent = () => {
@@ -82,17 +82,6 @@ export const UserMenu = ({ menu, userMenuMode, trigger }: IProperties) => {
             trigger={trigger}
           />
         );
-      case "collapsible-reverse":
-        return (
-          <NavGroup
-            className={`dz-user-menu ${userMenuMode}`}
-            navGroup={{
-              label: userMenuLabel,
-              submenu: refinedMenu,
-            }}
-          />
-        );
-      case "collapsible":
       default:
         return (
           <NavGroup
@@ -101,6 +90,7 @@ export const UserMenu = ({ menu, userMenuMode, trigger }: IProperties) => {
               label: userMenuLabel,
               submenu: refinedMenu,
             }}
+            displayMode={userMenuMode}
           />
         );
     }

--- a/packages/layout/src/components/Layout/common/UserMenu/UserMenu.tsx
+++ b/packages/layout/src/components/Layout/common/UserMenu/UserMenu.tsx
@@ -20,6 +20,7 @@ export const UserMenu = ({ menu, userMenuMode, trigger }: IProperties) => {
     () =>
       userMenu.map((_menu) => {
         return {
+          ..._menu,
           label: _menu.label as string,
           icon: _menu.icon,
           onClick: () => {
@@ -32,7 +33,7 @@ export const UserMenu = ({ menu, userMenuMode, trigger }: IProperties) => {
           },
         };
       }),
-    [userMenu]
+    [userMenu],
   );
 
   const renderContent = () => {

--- a/packages/layout/src/components/Layout/common/UserMenu/UserMenu.tsx
+++ b/packages/layout/src/components/Layout/common/UserMenu/UserMenu.tsx
@@ -80,16 +80,6 @@ export const UserMenu = ({ menu, userMenuMode, trigger }: IProperties) => {
             trigger={trigger}
           />
         );
-      case "collapsible":
-        return (
-          <NavGroup
-            className="dz-user-menu"
-            navGroup={{
-              label: userMenuLabel,
-              submenu: refinedMenu,
-            }}
-          />
-        );
       case "collapsible-reverse":
         return (
           <NavGroup
@@ -100,11 +90,10 @@ export const UserMenu = ({ menu, userMenuMode, trigger }: IProperties) => {
             }}
           />
         );
+      case "collapsible":
       default:
         return (
           <NavGroup
-            initialVisible={true}
-            collapsible={false}
             className="dz-user-menu"
             navGroup={{
               label: userMenuLabel,

--- a/packages/layout/src/components/Layout/types.ts
+++ b/packages/layout/src/components/Layout/types.ts
@@ -21,4 +21,8 @@ export type NavMenuItemType = {
 
 export type NavMenuType = NavMenuItemType | Array<NavMenuItemType>;
 
-export type UserMenuModeType = "horizontal" | "popup" | "expandable";
+export type UserMenuModeType =
+  | "horizontal"
+  | "popup"
+  | "collapsible"
+  | "collapsible-reverse";

--- a/packages/layout/src/components/Layout/types.ts
+++ b/packages/layout/src/components/Layout/types.ts
@@ -21,8 +21,9 @@ export type NavMenuItemType = {
 
 export type NavMenuType = NavMenuItemType | Array<NavMenuItemType>;
 
-export type UserMenuModeType =
-  | "horizontal"
-  | "popup"
+export type NavGroupDisplayMode =
   | "collapsible"
-  | "collapsible-reverse";
+  | "collapsible-reverse"
+  | "expanded";
+
+export type UserMenuModeType = NavGroupDisplayMode | "horizontal" | "popup";

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -21,6 +21,7 @@ import {
   SidebarHeaderLayout,
   SidebarHeaderLayoutProperties,
   SidebarOnlyLayout,
+  SidebarOnlyLayoutProperties,
 } from "./layouts";
 
 import type { DzangolabReactLayoutConfig } from "./types";
@@ -66,4 +67,4 @@ export type {
   NavMenuType,
 } from "./types";
 
-export type { SidebarHeaderLayoutProperties };
+export type { SidebarHeaderLayoutProperties, SidebarOnlyLayoutProperties };

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -17,8 +17,9 @@ import {
   useLayoutContext,
 } from "./components/Layout";
 import {
-  SidebarHeaderLayout,
   HeaderLayout,
+  SidebarHeaderLayout,
+  SidebarHeaderLayoutProperties,
   SidebarOnlyLayout,
 } from "./layouts";
 
@@ -64,3 +65,5 @@ export type {
   NavMenuItemType,
   NavMenuType,
 } from "./types";
+
+export type { SidebarHeaderLayoutProperties };

--- a/packages/layout/src/layouts/SidebarHeaderLayout.tsx
+++ b/packages/layout/src/layouts/SidebarHeaderLayout.tsx
@@ -1,3 +1,4 @@
+import { NavGroupDisplayMode } from "@/components/Layout";
 import { Header, Layout, NavMenuItemType, NavMenuType, Sidebar } from "..";
 
 export interface SidebarHeaderLayoutProperties {
@@ -16,7 +17,7 @@ export interface SidebarHeaderLayoutProperties {
   noToggle?: boolean;
   title?: string | React.ReactNode;
   userMenu?: NavMenuItemType;
-  userMenuMode?: "collapsible" | "collapsible-reverse";
+  userMenuMode?: NavGroupDisplayMode;
   userMenuLocation?: "sidebar" | "header";
   userMenuTrigger?: React.ReactNode;
 }

--- a/packages/layout/src/layouts/SidebarHeaderLayout.tsx
+++ b/packages/layout/src/layouts/SidebarHeaderLayout.tsx
@@ -1,4 +1,5 @@
 import { NavGroupDisplayMode } from "@/components/Layout";
+
 import { Header, Layout, NavMenuItemType, NavMenuType, Sidebar } from "..";
 
 export interface SidebarHeaderLayoutProperties {

--- a/packages/layout/src/layouts/SidebarHeaderLayout.tsx
+++ b/packages/layout/src/layouts/SidebarHeaderLayout.tsx
@@ -1,5 +1,3 @@
-import { UserMenuModeType } from "@/components/Layout";
-
 import { Header, Layout, NavMenuItemType, NavMenuType, Sidebar } from "..";
 
 export interface SidebarHeaderLayoutProperties {
@@ -43,24 +41,6 @@ export const SidebarHeaderLayout = ({
   userMenuLocation = "header",
   userMenuTrigger,
 }: SidebarHeaderLayoutProperties) => {
-  const getNavigationMenu = () => {
-    const userNavigationMenu = userMenu;
-
-    if (!userNavigationMenu) {
-      return navigationMenu;
-    }
-
-    if (!navigationMenu) {
-      return userNavigationMenu;
-    }
-
-    if (Array.isArray(navigationMenu)) {
-      return [...navigationMenu, userNavigationMenu];
-    }
-
-    return [navigationMenu, userNavigationMenu];
-  };
-
   return (
     <Layout
       className={`dz-sidebar-header-layout ${className || ""}`.trimEnd()}
@@ -81,7 +61,7 @@ export const SidebarHeaderLayout = ({
         <Sidebar
           collapsible={collapsible}
           displayNavIcons={displayNavIcons}
-          navigationMenu={getNavigationMenu()}
+          navigationMenu={navigationMenu}
           noHeader={noSidebarHeader}
           noFooter={noSidebarFooter}
           noLocaleSwitcher={noLocaleSwitcher}

--- a/packages/layout/src/layouts/SidebarHeaderLayout.tsx
+++ b/packages/layout/src/layouts/SidebarHeaderLayout.tsx
@@ -18,7 +18,7 @@ export interface SidebarHeaderLayoutProperties {
   noToggle?: boolean;
   title?: string | React.ReactNode;
   userMenu?: NavMenuItemType;
-  userMenuMode?: "popup" | "collapsible" | "collapsible-reverse";
+  userMenuMode?: "collapsible" | "collapsible-reverse";
   userMenuLocation?: "sidebar" | "header";
   userMenuTrigger?: React.ReactNode;
 }

--- a/packages/layout/src/layouts/SidebarHeaderLayout.tsx
+++ b/packages/layout/src/layouts/SidebarHeaderLayout.tsx
@@ -1,6 +1,8 @@
+import { UserMenuModeType } from "@/components/Layout";
+
 import { Header, Layout, NavMenuItemType, NavMenuType, Sidebar } from "..";
 
-interface IProperties {
+export interface SidebarHeaderLayoutProperties {
   children: React.ReactNode;
   className?: string;
   collapsible?: boolean;
@@ -16,6 +18,7 @@ interface IProperties {
   noToggle?: boolean;
   title?: string | React.ReactNode;
   userMenu?: NavMenuItemType;
+  userMenuMode?: "popup" | "collapsible" | "collapsible-reverse";
   userMenuLocation?: "sidebar" | "header";
   userMenuTrigger?: React.ReactNode;
 }
@@ -36,9 +39,10 @@ export const SidebarHeaderLayout = ({
   noToggle,
   title,
   userMenu,
+  userMenuMode,
   userMenuLocation = "header",
   userMenuTrigger,
-}: IProperties) => {
+}: SidebarHeaderLayoutProperties) => {
   const getNavigationMenu = () => {
     const userNavigationMenu = userMenu;
 
@@ -82,6 +86,7 @@ export const SidebarHeaderLayout = ({
           noFooter={noSidebarFooter}
           noLocaleSwitcher={noLocaleSwitcher}
           userMenu={userMenu}
+          userMenuMode={userMenuMode}
           trigger={userMenuTrigger}
         ></Sidebar>
       )}

--- a/packages/layout/src/layouts/SidebarOnlyLayout.tsx
+++ b/packages/layout/src/layouts/SidebarOnlyLayout.tsx
@@ -5,7 +5,7 @@ import {
   NavMenuItemType,
 } from "@/components/Layout";
 
-interface SidebarOnlyLayoutProperties {
+export interface SidebarOnlyLayoutProperties {
   className?: string;
   children: React.ReactNode;
   collapsible?: boolean;
@@ -16,7 +16,7 @@ interface SidebarOnlyLayoutProperties {
   noSidebarHeader?: boolean;
   noSidebarFooter?: boolean;
   userMenu?: NavMenuItemType;
-  userMenuTrigger?: React.ReactNode;
+  userMenuMode?: "collapsible" | "collapsible-reverse";
 }
 
 export const SidebarOnlyLayout: React.FC<SidebarOnlyLayoutProperties> = ({
@@ -30,7 +30,7 @@ export const SidebarOnlyLayout: React.FC<SidebarOnlyLayoutProperties> = ({
   noSidebarHeader,
   noSidebarFooter,
   userMenu,
-  userMenuTrigger,
+  userMenuMode,
 }) => {
   return (
     <Layout className={`dz-sidebar-only-layout ${className || ""}`.trimEnd()}>
@@ -43,7 +43,7 @@ export const SidebarOnlyLayout: React.FC<SidebarOnlyLayoutProperties> = ({
           noFooter={noSidebarFooter}
           noLocaleSwitcher={noLocaleSwitcher}
           userMenu={userMenu}
-          trigger={userMenuTrigger}
+          userMenuMode={userMenuMode}
         ></Sidebar>
       )}
       <main>{children}</main>

--- a/packages/layout/src/layouts/SidebarOnlyLayout.tsx
+++ b/packages/layout/src/layouts/SidebarOnlyLayout.tsx
@@ -3,6 +3,7 @@ import {
   Sidebar,
   NavMenuType,
   NavMenuItemType,
+  NavGroupDisplayMode,
 } from "@/components/Layout";
 
 export interface SidebarOnlyLayoutProperties {
@@ -16,7 +17,7 @@ export interface SidebarOnlyLayoutProperties {
   noSidebarHeader?: boolean;
   noSidebarFooter?: boolean;
   userMenu?: NavMenuItemType;
-  userMenuMode?: "collapsible" | "collapsible-reverse";
+  userMenuMode?: NavGroupDisplayMode;
 }
 
 export const SidebarOnlyLayout: React.FC<SidebarOnlyLayoutProperties> = ({

--- a/packages/user/src/layouts/UserEnabledSidebarHeaderLayout.tsx
+++ b/packages/user/src/layouts/UserEnabledSidebarHeaderLayout.tsx
@@ -67,19 +67,8 @@ export const UserEnabledSidebarHeaderLayout: React.FC<Properties> = ({
       children={children}
       className={className}
       collapsible={collapsible}
-      navigationMenu={navigationMenu}
-      userMenu={
-        user
-          ? getUserNavigationMenu()
-          : authNavigationMenu
-            ? {
-                ...authNavigationMenu,
-                className: `dz-auth-menu ${
-                  authNavigationMenu?.className || ""
-                }`.trim(),
-              }
-            : undefined
-      }
+      navigationMenu={user ? navigationMenu : authNavigationMenu}
+      userMenu={user ? getUserNavigationMenu() : undefined}
       userMenuLocation={userMenuLocation}
       {...otherProperties}
     />

--- a/packages/user/src/layouts/UserEnabledSidebarHeaderLayout.tsx
+++ b/packages/user/src/layouts/UserEnabledSidebarHeaderLayout.tsx
@@ -1,35 +1,19 @@
 import { useTranslation } from "@dzangolab/react-i18n";
 import {
-  SidebarHeaderLayout,
-  NavMenuType,
   NavMenuItemType,
+  SidebarHeaderLayout,
+  SidebarHeaderLayoutProperties,
 } from "@dzangolab/react-layout";
 import { toast } from "react-toastify";
 
 import { useUser } from "@/hooks";
 import logout from "@/supertokens/logout";
 
-interface Properties {
+interface Properties extends SidebarHeaderLayoutProperties {
   authNavigationMenu?: NavMenuItemType;
-  children: React.ReactNode;
-  className?: string;
-  collapsible?: boolean;
-  customHeader?: React.ReactNode;
-  customSidebar?: React.ReactNode;
-  displayNavIcons?: boolean;
-  headerAddon?: React.ReactNode;
-  navigationMenu?: NavMenuType;
-  noLocaleSwitcher?: boolean;
-  noLogo?: boolean;
-  noSidebarHeader?: boolean;
-  noSidebarFooter?: boolean;
-  noToggle?: boolean;
-  title?: string | React.ReactNode;
   userNavigationMenu?: NavMenuItemType;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onLogout?: () => Promise<any>;
-  userMenuLocation?: "sidebar" | "header";
-  userMenuTrigger?: React.ReactNode;
 }
 
 export const UserEnabledSidebarHeaderLayout: React.FC<Properties> = ({

--- a/packages/user/src/layouts/UserEnabledSidebarOnlyLayout.tsx
+++ b/packages/user/src/layouts/UserEnabledSidebarOnlyLayout.tsx
@@ -78,31 +78,13 @@ export const UserEnabledSidebarOnlyLayout: React.FC<Properties> = ({
     };
   };
 
-  const getNavigationMenu = () => {
-    const userNavigationMenu = getUserNavigationMenu();
-
-    if (!userNavigationMenu) {
-      return navigationMenu;
-    }
-
-    if (!navigationMenu) {
-      return userNavigationMenu;
-    }
-
-    if (Array.isArray(navigationMenu)) {
-      return [...navigationMenu, userNavigationMenu];
-    }
-
-    return [navigationMenu, userNavigationMenu];
-  };
-
   return (
     <SidebarOnlyLayout
       children={children}
       className={className}
       collapsible={collapsible}
       displayNavIcons={displayNavIcons}
-      navigationMenu={getNavigationMenu()}
+      navigationMenu={user ? navigationMenu : authNavigationMenu}
       customSidebar={customSidebar}
       noSidebarHeader={noSidebarHeader}
       noSidebarFooter={noSidebarFooter}

--- a/packages/user/src/layouts/UserEnabledSidebarOnlyLayout.tsx
+++ b/packages/user/src/layouts/UserEnabledSidebarOnlyLayout.tsx
@@ -5,23 +5,16 @@ import { toast } from "react-toastify";
 import { useUser } from "@/hooks";
 import logout from "@/supertokens/logout";
 
-import type { NavMenuItemType, NavMenuType } from "@dzangolab/react-layout";
+import type {
+  NavMenuItemType,
+  SidebarOnlyLayoutProperties,
+} from "@dzangolab/react-layout";
 
-interface Properties {
+interface Properties extends Omit<SidebarOnlyLayoutProperties, "userMenu"> {
   authNavigationMenu?: NavMenuItemType;
-  children: React.ReactNode;
-  className?: string;
-  collapsible?: boolean;
-  customSidebar?: React.ReactNode;
-  displayNavIcons?: boolean;
-  navigationMenu?: NavMenuType;
   userNavigationMenu?: NavMenuItemType;
-  noSidebarHeader?: boolean;
-  noSidebarFooter?: boolean;
-  noLocaleSwitcher?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onLogout?: () => Promise<any>;
-  userMenuTrigger?: React.ReactNode;
 }
 
 export const UserEnabledSidebarOnlyLayout: React.FC<Properties> = ({
@@ -36,8 +29,8 @@ export const UserEnabledSidebarOnlyLayout: React.FC<Properties> = ({
   noSidebarFooter,
   noLocaleSwitcher,
   userNavigationMenu,
+  userMenuMode,
   onLogout,
-  userMenuTrigger,
 }) => {
   const { t } = useTranslation("user");
 
@@ -115,7 +108,7 @@ export const UserEnabledSidebarOnlyLayout: React.FC<Properties> = ({
       noSidebarFooter={noSidebarFooter}
       noLocaleSwitcher={noLocaleSwitcher}
       userMenu={user ? getUserNavigationMenu() : undefined}
-      userMenuTrigger={userMenuTrigger}
+      userMenuMode={userMenuMode}
     />
   );
 };


### PR DESCRIPTION
- refactor(css): remove redundant css for sidebar-only and sidebar-header layout.
- feat(user-menu): update `useMenu` component to support upward expansion. 