### PR TITLE
feat(ui/table): preserve table state on page reload

### DIFF
--- a/packages/ui/src/Table/Table.tsx
+++ b/packages/ui/src/Table/Table.tsx
@@ -22,7 +22,12 @@ import { DataActionsMenu } from "./TableDataActions";
 import { Table, TableFooter } from "./TableElements";
 import { TableHeader } from "./TableHeader";
 import { TableToolbar } from "./TableToolbar";
-import { getRequestJSON, getParsedColumns } from "./utils";
+import {
+  getRequestJSON,
+  getParsedColumns,
+  setStorageItem,
+  getStorageItem,
+} from "./utils";
 import { Checkbox } from "../FormWidgets";
 import LoadingIcon from "../LoadingIcon";
 import { Pagination } from "../Pagination";
@@ -230,43 +235,34 @@ const DataTable = <TData extends { id: string | number }>({
       return;
     }
 
-    try {
-      const savedState = sessionStorage.getItem(id);
+    const savedState = getStorageItem(id);
 
-      if (savedState) {
-        const { columnFilters, columnVisibility, sorting } =
-          JSON.parse(savedState);
+    if (savedState) {
+      const { columnFilters, columnVisibility, sorting } =
+        JSON.parse(savedState);
 
-        // Note: order matters here
-        if (columnFilters?.length) {
-          setColumnFilters(columnFilters);
-        }
-
-        if (Object.entries(columnVisibility).length) {
-          setColumnVisibility(columnVisibility);
-        }
-
-        if (sorting?.length) {
-          setSorting(sorting);
-        }
+      if (columnFilters?.length) {
+        setColumnFilters(columnFilters);
       }
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log("Sorry, something went wrong", error);
+
+      if (Object.entries(columnVisibility).length) {
+        setColumnVisibility(columnVisibility);
+      }
+
+      if (sorting?.length) {
+        setSorting(sorting);
+      }
     }
   }, [id]);
 
   useEffect(() => {
     return () => {
       if (id) {
-        sessionStorage.setItem(
-          id,
-          JSON.stringify({
-            columnFilters,
-            columnVisibility,
-            sorting,
-          }),
-        );
+        setStorageItem(id, {
+          columnFilters,
+          columnVisibility,
+          sorting,
+        });
       }
     };
   }, [id, columnFilters, columnVisibility, sorting]);

--- a/packages/ui/src/Table/Table.tsx
+++ b/packages/ui/src/Table/Table.tsx
@@ -191,6 +191,7 @@ const DataTable = <TData extends { id: string | number }>({
     : table.getFilteredRowModel().rows?.length;
 
   useEffect(() => {
+    // client side rendering
     if (!fetchData && !paginated) {
       setPagination((previous) => ({
         ...previous,
@@ -223,6 +224,67 @@ const DataTable = <TData extends { id: string | number }>({
       table.setColumnOrder(["select", ...visibleColumns]);
     }
   }, [visibleColumns, parsedColumns]);
+
+  useEffect(() => {
+    if (!id) {
+      return;
+    }
+
+    try {
+      const savedState = localStorage.getItem(id);
+
+      if (savedState) {
+        const {
+          columnFilters,
+          columnVisibility,
+          pagination,
+          rowSelection,
+          sorting,
+        } = JSON.parse(savedState);
+
+        // Note: order matters here
+        if (columnFilters?.length) {
+          setColumnFilters(columnFilters);
+        }
+
+        if (Object.entries(columnVisibility).length) {
+          setColumnVisibility(columnVisibility);
+        }
+
+        if (Object.entries(rowSelection).length) {
+          setRowSelection(rowSelection);
+        }
+
+        if (sorting?.length) {
+          setSorting(sorting);
+        }
+
+        if (Object.entries(pagination).length) {
+          setPagination(pagination);
+        }
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log("Sorry, something went wrong", error);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    return () => {
+      if (id) {
+        localStorage.setItem(
+          id,
+          JSON.stringify({
+            columnFilters,
+            columnVisibility,
+            pagination,
+            rowSelection,
+            sorting,
+          }),
+        );
+      }
+    };
+  }, [id, columnFilters, columnVisibility, pagination, rowSelection, sorting]);
 
   return (
     <div id={id} className={("dz-table-container " + className).trimEnd()}>

--- a/packages/ui/src/Table/Table.tsx
+++ b/packages/ui/src/Table/Table.tsx
@@ -25,8 +25,8 @@ import { TableToolbar } from "./TableToolbar";
 import {
   getRequestJSON,
   getParsedColumns,
-  setStorageItem,
-  getStorageItem,
+  saveTableState,
+  getTableState,
 } from "./utils";
 import { Checkbox } from "../FormWidgets";
 import LoadingIcon from "../LoadingIcon";
@@ -235,7 +235,7 @@ const DataTable = <TData extends { id: string | number }>({
       return;
     }
 
-    const savedState = getStorageItem(id);
+    const savedState = getTableState(id);
 
     if (savedState) {
       const { columnFilters, columnVisibility, sorting } =
@@ -258,7 +258,7 @@ const DataTable = <TData extends { id: string | number }>({
   useEffect(() => {
     return () => {
       if (id) {
-        setStorageItem(id, {
+        saveTableState(id, {
           columnFilters,
           columnVisibility,
           sorting,

--- a/packages/ui/src/Table/Table.tsx
+++ b/packages/ui/src/Table/Table.tsx
@@ -26,7 +26,7 @@ import {
   getRequestJSON,
   getParsedColumns,
   saveTableState,
-  getTableState,
+  getSavedTableState,
 } from "./utils";
 import { Checkbox } from "../FormWidgets";
 import LoadingIcon from "../LoadingIcon";
@@ -62,6 +62,7 @@ const DataTable = <TData extends { id: string | number }>({
   onRowSelectChange,
   totalRecords = 0,
   paginationOptions,
+  persistTableState = false,
   showColumnsAction = false,
   ...tableOptions
 }: TDataTableProperties<TData>) => {
@@ -231,15 +232,14 @@ const DataTable = <TData extends { id: string | number }>({
   }, [visibleColumns, parsedColumns]);
 
   useEffect(() => {
-    if (!id) {
+    if (!persistTableState || !id) {
       return;
     }
 
-    const savedState = getTableState(id);
+    const savedState = getSavedTableState(id);
 
     if (savedState) {
-      const { columnFilters, columnVisibility, sorting } =
-        JSON.parse(savedState);
+      const { columnFilters, columnVisibility, sorting } = savedState;
 
       if (columnFilters?.length) {
         setColumnFilters(columnFilters);
@@ -253,11 +253,11 @@ const DataTable = <TData extends { id: string | number }>({
         setSorting(sorting);
       }
     }
-  }, [id]);
+  }, [id, persistTableState]);
 
   useEffect(() => {
     return () => {
-      if (id) {
+      if (persistTableState && id) {
         saveTableState(id, {
           columnFilters,
           columnVisibility,
@@ -265,7 +265,7 @@ const DataTable = <TData extends { id: string | number }>({
         });
       }
     };
-  }, [id, columnFilters, columnVisibility, sorting]);
+  }, [id, columnFilters, columnVisibility, persistTableState, sorting]);
 
   return (
     <div id={id} className={("dz-table-container " + className).trimEnd()}>

--- a/packages/ui/src/Table/Table.tsx
+++ b/packages/ui/src/Table/Table.tsx
@@ -62,7 +62,7 @@ const DataTable = <TData extends { id: string | number }>({
   onRowSelectChange,
   totalRecords = 0,
   paginationOptions,
-  persistTableState = false,
+  persistState = false,
   showColumnsAction = false,
   ...tableOptions
 }: TDataTableProperties<TData>) => {
@@ -232,7 +232,7 @@ const DataTable = <TData extends { id: string | number }>({
   }, [visibleColumns, parsedColumns]);
 
   useEffect(() => {
-    if (!persistTableState || !id) {
+    if (!persistState || !id) {
       return;
     }
 
@@ -253,11 +253,11 @@ const DataTable = <TData extends { id: string | number }>({
         setSorting(sorting);
       }
     }
-  }, [id, persistTableState]);
+  }, [id, persistState]);
 
   useEffect(() => {
     return () => {
-      if (persistTableState && id) {
+      if (persistState && id) {
         saveTableState(id, {
           columnFilters,
           columnVisibility,
@@ -265,7 +265,7 @@ const DataTable = <TData extends { id: string | number }>({
         });
       }
     };
-  }, [id, columnFilters, columnVisibility, persistTableState, sorting]);
+  }, [id, columnFilters, columnVisibility, persistState, sorting]);
 
   return (
     <div id={id} className={("dz-table-container " + className).trimEnd()}>

--- a/packages/ui/src/Table/Table.tsx
+++ b/packages/ui/src/Table/Table.tsx
@@ -231,16 +231,11 @@ const DataTable = <TData extends { id: string | number }>({
     }
 
     try {
-      const savedState = localStorage.getItem(id);
+      const savedState = sessionStorage.getItem(id);
 
       if (savedState) {
-        const {
-          columnFilters,
-          columnVisibility,
-          pagination,
-          rowSelection,
-          sorting,
-        } = JSON.parse(savedState);
+        const { columnFilters, columnVisibility, sorting } =
+          JSON.parse(savedState);
 
         // Note: order matters here
         if (columnFilters?.length) {
@@ -251,16 +246,8 @@ const DataTable = <TData extends { id: string | number }>({
           setColumnVisibility(columnVisibility);
         }
 
-        if (Object.entries(rowSelection).length) {
-          setRowSelection(rowSelection);
-        }
-
         if (sorting?.length) {
           setSorting(sorting);
-        }
-
-        if (Object.entries(pagination).length) {
-          setPagination(pagination);
         }
       }
     } catch (error) {
@@ -272,19 +259,17 @@ const DataTable = <TData extends { id: string | number }>({
   useEffect(() => {
     return () => {
       if (id) {
-        localStorage.setItem(
+        sessionStorage.setItem(
           id,
           JSON.stringify({
             columnFilters,
             columnVisibility,
-            pagination,
-            rowSelection,
             sorting,
           }),
         );
       }
     };
-  }, [id, columnFilters, columnVisibility, pagination, rowSelection, sorting]);
+  }, [id, columnFilters, columnVisibility, sorting]);
 
   return (
     <div id={id} className={("dz-table-container " + className).trimEnd()}>

--- a/packages/ui/src/Table/types.ts
+++ b/packages/ui/src/Table/types.ts
@@ -15,6 +15,7 @@ import type {
   Column,
   RowData,
   SortingState,
+  VisibilityState,
 } from "@tanstack/react-table";
 import type { ComponentProps, ReactNode } from "react";
 
@@ -270,6 +271,7 @@ export interface TDataTableProperties<TData>
     align?: "left" | "center" | "right";
   };
   paginated?: boolean;
+  persistTableState?: boolean;
   rowPerPage?: number;
   rowPerPageOptions?: number[];
   visibleColumns?: string[];
@@ -301,3 +303,9 @@ export type {
   FilterFn as FilterFunction,
   FilterFns as FilterFunctions,
 } from "@tanstack/react-table";
+
+export interface PersistentTableState {
+  columnFilters: ColumnFiltersState;
+  columnVisibility: VisibilityState;
+  sorting: SortingState;
+}

--- a/packages/ui/src/Table/types.ts
+++ b/packages/ui/src/Table/types.ts
@@ -271,7 +271,7 @@ export interface TDataTableProperties<TData>
     align?: "left" | "center" | "right";
   };
   paginated?: boolean;
-  persistTableState?: boolean;
+  persistState?: boolean;
   rowPerPage?: number;
   rowPerPageOptions?: number[];
   visibleColumns?: string[];

--- a/packages/ui/src/Table/utils.ts
+++ b/packages/ui/src/Table/utils.ts
@@ -334,7 +334,7 @@ export const getSavedTableState = (id: string): PersistentTableState | null => {
     return savedState && JSON.parse(savedState);
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.log("[Dz table] Sorry, could not restore persisted state", error);
+    console.log("[Dz table] Could not restore table state", error);
   }
 
   return null;
@@ -345,6 +345,6 @@ export const saveTableState = (id: string, value: PersistentTableState) => {
     sessionStorage.setItem(id, JSON.stringify(value));
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.log("[Dz table] Sorry, could not store persistent state", error);
+    console.log("[Dz table] Could not store table state", error);
   }
 };

--- a/packages/ui/src/Table/utils.ts
+++ b/packages/ui/src/Table/utils.ts
@@ -345,6 +345,6 @@ export const saveTableState = (id: string, value: PersistentTableState) => {
     sessionStorage.setItem(id, JSON.stringify(value));
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.log("[Dz table] Sorry, could not store persisted state", error);
+    console.log("[Dz table] Sorry, could not store persistent state", error);
   }
 };

--- a/packages/ui/src/Table/utils.ts
+++ b/packages/ui/src/Table/utils.ts
@@ -329,7 +329,7 @@ export const getAlignValue = ({
 /**
  * Get a item from storage for given key
  */
-export const getStorageItem = (key: string) => {
+export const getTableState = (key: string) => {
   try {
     return sessionStorage.getItem(key);
   } catch (error) {
@@ -341,7 +341,7 @@ export const getStorageItem = (key: string) => {
 /**
  * Save a item to the storage with a given key
  */
-export const setStorageItem = (
+export const saveTableState = (
   key: string,
   value: object | string | number | boolean | null,
 ) => {

--- a/packages/ui/src/Table/utils.ts
+++ b/packages/ui/src/Table/utils.ts
@@ -325,3 +325,25 @@ export const getAlignValue = ({
     return "left";
   }
 };
+
+/**
+ * Get a item from storage for given key
+ */
+export const getStorageItem = (key: string) => {
+  try {
+    return sessionStorage.getItem(key);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log("[Dz table] Sorry, could not restore persisted state", error);
+  }
+};
+
+/**
+ * Save a item to the storage with a given key
+ */
+export const setStorageItem = (
+  key: string,
+  value: object | string | number | boolean | null,
+) => {
+  sessionStorage.setItem(key, JSON.stringify(value));
+};

--- a/packages/ui/src/Table/utils.ts
+++ b/packages/ui/src/Table/utils.ts
@@ -3,6 +3,7 @@ import type {
   CellDataType,
   FormatDateType,
   FormatNumberType,
+  PersistentTableState,
   TFilterFn as TFilterFunction,
   TRequestJSON,
   TSortDirection,
@@ -326,24 +327,24 @@ export const getAlignValue = ({
   }
 };
 
-/**
- * Get a item from storage for given key
- */
-export const getTableState = (key: string) => {
+export const getSavedTableState = (id: string): PersistentTableState | null => {
   try {
-    return sessionStorage.getItem(key);
+    const savedState = sessionStorage.getItem(id);
+
+    return savedState && JSON.parse(savedState);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log("[Dz table] Sorry, could not restore persisted state", error);
   }
+
+  return null;
 };
 
-/**
- * Save a item to the storage with a given key
- */
-export const saveTableState = (
-  key: string,
-  value: object | string | number | boolean | null,
-) => {
-  sessionStorage.setItem(key, JSON.stringify(value));
+export const saveTableState = (id: string, value: PersistentTableState) => {
+  try {
+    sessionStorage.setItem(id, JSON.stringify(value));
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log("[Dz table] Sorry, could not store persisted state", error);
+  }
 };


### PR DESCRIPTION
- use session storage to store the sorting, columnFilters, and columnVisibility states
- use `id` prop for storage key
- add `persistState` prop to enable/disable the state persistence
- add try catch for case when stored JSON data in localStorage may become corrupted