### PR TITLE
feat(table): add support to limit date  for date range filter

### DIFF
--- a/apps/demo/src/Views/Ui/components/Table/Table.tsx
+++ b/apps/demo/src/Views/Ui/components/Table/Table.tsx
@@ -1012,6 +1012,7 @@ export const TableDemo = () => {
               filterPlaceholder: t("table.placeholder.date"),
               header: "Date",
               meta: {
+                dateFilterMax: new Date(),
                 filterVariant: "dateRange",
               },
             },
@@ -1023,6 +1024,7 @@ export const TableDemo = () => {
               filterPlaceholder: t("table.placeholder.date"),
               header: "Datetime",
               meta: {
+                dateFilterMin: new Date(2024, 0, 1),
                 filterVariant: "dateRange",
               },
             },

--- a/packages/ui/src/Table/TableDateFilter.tsx
+++ b/packages/ui/src/Table/TableDateFilter.tsx
@@ -38,9 +38,13 @@ export const TableDateFilter = <TData,>({
     return null;
   };
 
+  const meta = column.columnDef.meta;
+
   return (
     <DatePicker
       inputRef={null}
+      maxDate={meta?.dateFilterMax}
+      minDate={meta?.dateFilterMin}
       name="date-range"
       onChange={(date) => {
         if (!date) {

--- a/packages/ui/src/Table/types.ts
+++ b/packages/ui/src/Table/types.ts
@@ -44,6 +44,8 @@ declare module "@tanstack/react-table" {
 
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   interface ColumnMeta<TData extends RowData, TValue> {
+    dateFilterMax?: Date;
+    dateFilterMin?: Date;
     filterOptions?: FilterOption[];
     filterVariant?: TFilterVariant;
     rangeFilterMax?: number;


### PR DESCRIPTION
- Extended ColumnMeta types (packages/ui/src/Table/types.ts) — Added optional dateFilterMin and dateFilterMax properties to the column meta interface.
- Wired into TableDateFilter (packages/ui/src/Table/TableDateFilter.tsx) — Passed minDate and maxDate from column meta to the underlying DatePicker component, enabling date boundary enforcement.
